### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["noarch"]
 language = "zh-Hans"
-multilingual = false
 src = "src"
 title = "privacy.noarch"
 description = "一本面向新手的隐私教程"


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10